### PR TITLE
Install django-shop with an egg of "django-shop" not "shop"

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,4 +6,4 @@ django-mptt
 
 # contains migrations necessary for Django 1.8 that are not
 # available upstream
--e git+https://github.com/nimbis/django-shop@master#egg=shop
+-e git+https://github.com/nimbis/django-shop@master#egg=django-shop

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-django>=1.8
+django>=1.8,<1.9
 image
 django-cms>=3.1.1
 django-treebeard


### PR DESCRIPTION
Otherwise, pip might be confused into pulling in an older version of
"django-shop" not realizing that the thing we pulled in as "shop" is
already a git-master of the same thing.

And since old versions of django-shop, in turn, pull in dependencies
(such as South) that break other packages, we really need to avoid
that.